### PR TITLE
[Feature] 알림 생성 시 메시지 전송 권한을 확인하는 기능 구현

### DIFF
--- a/src/service/userInfoAPI.js
+++ b/src/service/userInfoAPI.js
@@ -23,6 +23,23 @@ export default {
       console.error('Error fetching user info:', error);
       await router.push('/login');
     }
+  },
+
+  async checkTalkMessage() {
+    const token = sessionStorage.getItem('accessToken');
+    try {
+      const response = await axios.get(
+          `${import.meta.env.VITE_APP_KAKAO_USER_SCOPES_URI}?scopes=["talk_message"]`,
+          {
+            headers: {
+              "Authorization": "Bearer " + `${token}`
+            }
+          });
+      const data = response.data;
+      return data.scopes[0].agreed;
+    } catch (error) {
+      console.error('Error fetching user info:', error);
+    }
   }
 
 }

--- a/src/views/NotificationCreation.vue
+++ b/src/views/NotificationCreation.vue
@@ -68,6 +68,7 @@
 
 <script>
 import {mapState, mapActions} from 'vuex';
+import userInfoAPI from "@/service/userInfoAPI.js";
 
 export default {
   computed: {
@@ -84,11 +85,18 @@ export default {
     ...mapActions('modalStore', ['openModal', 'closeModal']),
 
     // 알림 생성 버튼 클릭 시 모달 열기
-    openModal() {
-      this.$store.dispatch('modalStore/openModal');
+    async openModal() {
       this.content = '';
       this.time = '';
       this.selectedDays = [];
+      const agreement = await userInfoAPI.checkTalkMessage();
+      if (agreement === false) {
+        alert('카카오톡 메시지 전송 동의 후 이용가능합니다.')
+        window.location.href = import.meta.env.VITE_APP_KAKAO_AUTHORIZATION_URI
+            + '&scope=talk_message';
+      } else {
+        this.$store.dispatch('modalStore/openModal');
+      }
     },
 
     // 모달 닫기


### PR DESCRIPTION
## 🔥 Related Issue

close: #11 

## 📝 Description
알림 생성 시에 카카오 메시지 전송 권한을 확인 후 비동의일 경우 동의 화면으로 이동합니다.

## ⭐️ Review
추후 기본 알림이 추가되면 기본 알림 활성화 시에도 해당 기능을 사용합니다.